### PR TITLE
Add EcmaScript 2015 transpiling to the 'javascript' task

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,31 @@ Add to bower.json
 }
 ```
 
+## Javascript task
+
+To use the EcmaScript 2015 (ES6) transpiling, add the following dependencies:
+```bash
+npm install babel-preset-es2015 gulp-babel gulp-plumber --save-dev
+```
+
+Example configuration:
+```json
+    "javascript": {
+        "items": [
+            {
+                "src": [
+                    "bower_components/babel-polyfill/browser-polyfill.js",
+                    "javascript/app.js"
+                ],
+                "outputname": "app.js",
+                "dest": "../../web/assets/javascript/",
+                "options": {},
+                "es2015": true
+            }
+        ],
+    }
+```
+
 ## Inline images task
 
 With the task inline-images you can create a 'sprite' of inline css images. The task

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
     "tasks"
   ],
   "dependencies": {
-    "gulp-iconfont-template": "git@github.com:ConnectHolland/gulp-iconfont-template.git#^2.0.3"
+    "gulp-iconfont-template": "git@github.com:ConnectHolland/gulp-iconfont-template.git#^2.0.3",
+    "babel-polyfill": "^0.0.1"
   },
   "license": "MIT",
   "private": true,

--- a/tasks/javascript.js
+++ b/tasks/javascript.js
@@ -8,8 +8,17 @@ module.exports = function (gulp, config, plugins) {
                 plugins['include'] = plugins.util.noop;
             }
 
-            return gulp.src(item.src)
-                .pipe(plugins.sourcemaps.init())
+            var result = gulp.src(item.src)
+                .pipe(plugins.sourcemaps.init());
+
+            if (item.es2015 === true) {
+                // Transpile es2015
+                result
+                    .pipe(plugins.plumber())
+                    .pipe(plugins.babel({presets: ['es2015']}));
+            }
+
+            result
                 .pipe(plugins.concat(item.outputname))
                 .pipe(plugins.include() )
                 .pipe(
@@ -20,6 +29,8 @@ module.exports = function (gulp, config, plugins) {
                 )
                 .pipe(gulp.dest(item.dest))
                 .pipe(plugins.livereload());
+            
+            return result;
         });
     };
 };


### PR DESCRIPTION
Add EcmaScript 2015 (ES6) transpiling to the 'javascript' task. All es2015 available from the Babel transpiler is available. For additional options (like Intl) use separate polyfills.
