### PR TITLE
Update _template.scss

### DIFF
--- a/tasks/icons/_template.scss
+++ b/tasks/icons/_template.scss
@@ -1,13 +1,21 @@
 @charset 'utf-8';
 
+$version: '<%= _.join([
+    _.sample('0123456789'),
+    _.sample('0123456789'),
+    _.sample('0123456789'),
+    _.sample('0123456789'),
+    _.sample('0123456789'),
+    ], '' ) %>';
+
 @font-face {
     font-family: '<%= fontName %>';
-    src: url('<%= fontPath %><%= fontName %>.eot');
-    src: url('<%= fontPath %><%= fontName %>.eot?#iefix') format('eot')<% if (formats.indexOf('woff2') !== -1) { %>,
-        url('<%= fontPath %><%= fontName %>.woff2') format('woff2')<% } %>,
-        url('<%= fontPath %><%= fontName %>.woff') format('woff'),
-        url('<%= fontPath %><%= fontName %>.ttf') format('truetype')<% if (formats.indexOf('svg') !== -1) { %>,
-        url('<%= fontPath %><%= fontName %>.svg#<%= fontName %>') format('svg')<% } %>;
+    src: url('<%= fontPath %><%= fontName %>.eot?v#{$version}');
+    src: url('<%= fontPath %><%= fontName %>.eot?v#{$version}#iefix') format('eot')<% if (formats.indexOf('woff2') !== -1) { %>,
+        url('<%= fontPath %><%= fontName %>.woff2?v#{$version}') format('woff2')<% } %>,
+        url('<%= fontPath %><%= fontName %>.woff?v#{$version}') format('woff'),
+        url('<%= fontPath %><%= fontName %>.ttf?v#{$version}') format('truetype')<% if (formats.indexOf('svg') !== -1) { %>,
+        url('<%= fontPath %><%= fontName %>.svg?v#{$version}#<%= fontName %>') format('svg')<% } %>;
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
This generate a random 5 digit number that is used to version the icon font files, this avoid showing the wrong icons after adding new icons to a site.

Does this work in IE 11 | yes
Does this work in IE Edge | yes
Does this work in Chrome | yes
Does this work in Firefox | yes
Does this work in Safari | yes

When running `gulp icons` this will be the new result.
```
$version: '03818';

@font-face {
    font-family: 'icon';
    src: url('/bundles/clientwebsite/font/icon.eot?v#{$version}');
    src: url('/bundles/clientwebsite/font/icon.eot?v#{$version}#iefix') format('eot'),
        url('/bundles/clientwebsite/font/icon.woff2?v#{$version}') format('woff2'),
        url('/bundles/clientwebsite/font/icon.woff?v#{$version}') format('woff'),
        url('/bundles/clientwebsite/font/icon.ttf?v#{$version}') format('truetype'),
        url('/bundles/clientwebsite/font/icon.svg?v#{$version}#icon') format('svg');
    font-weight: normal;
    font-style: normal;
}
```